### PR TITLE
Add logo to header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,9 +27,18 @@ export default function HomePage() {
     <div className="flex flex-col min-h-screen max-w-7xl mx-auto">
       {/* Header */}
       <header className="px-4 lg:px-6 h-16 flex items-center border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 sticky top-0 z-50">
-        <Link href="/" className="flex items-center justify-center">
-          <span className="text-2xl font-bold text-primary">KEERTHI</span>
-          <span className="ml-2 text-sm text-muted-foreground">GROUP</span>
+        <Link href="/" className="flex items-center justify-center space-x-2">
+          <Image
+            src="/logo.png"
+            width={60}
+            height={32}
+            alt="Keerthi Group Logo"
+            className="h-8 w-auto"
+          />
+          <div className="flex flex-col leading-none">
+            <span className="text-2xl font-bold text-primary">KEERTHI</span>
+            <span className="text-sm text-muted-foreground">GROUP</span>
+          </div>
         </Link>
         <nav className="ml-auto flex gap-4 sm:gap-6">
           <Link href="#divisions" className="text-sm font-medium hover:underline underline-offset-4">


### PR DESCRIPTION
## Summary
- show the company logo in the page header and keep the title text

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a265f1c108322a8ed6cc3b3666519