### PR TITLE
Improve responsive layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body className="m-0 mx-auto max-w-7xl">{children}</body>
+      <body className="m-0 mx-auto w-full">{children}</body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,7 @@ import Image from "next/image"
 
 export default function HomePage() {
   return (
-    <div className="flex flex-col min-h-screen max-w-7xl mx-auto">
+    <div className="flex flex-col min-h-screen w-full mx-auto">
       {/* Header */}
       <header className="px-4 lg:px-6 h-16 flex items-center border-b bg-black text-white sticky top-0 z-50">
         <Link href="/" className="flex items-center justify-center space-x-2">


### PR DESCRIPTION
## Summary
- make root layout width full instead of restricted
- ensure homepage container uses full width

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68809e0e57748322b8023192a64cc79d