### PR TITLE
Remove wrapper div in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
 
-      <body className="m-0 mx-auto w-full max-w-7xl px-4">{children}</body>
+      <body className="m-0 w-full overflow-x-hidden bg-white text-black">{children}</body>
 
     </html>
   )


### PR DESCRIPTION
## Summary
- remove max-width wrapper from `layout.tsx` so full-width backgrounds work

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a7b1e1348322aa6c7380f83bfc83